### PR TITLE
Search suggestions support

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -39,6 +39,12 @@ if (Compat.isRunningInWebExtension()) {
         }),
         // Gets one or more items from storage.
         getItem: key => new Promise(resolve => {
+            // if localStorage is not defined, return null.
+            // Can happen in some environments like Node.js.
+            if (typeof localStorage === 'undefined') {
+                resolve(null);
+            }
+
             let val = localStorage.getItem(key);
             if (val) {
                 try {

--- a/src/routes/redirect/[query]/+server.js
+++ b/src/routes/redirect/[query]/+server.js
@@ -1,0 +1,55 @@
+import { redirect } from "@sveltejs/kit";
+import { DescShardManager, IndexManager } from "querylib";
+import { CrateSearch, DocSearch } from "querylib/search";
+
+/**
+ * This function behaves as a redirector for the search queries.
+ * 
+ * There are two types of search queries:
+ * A keyword query. This is a known word followed by a colon and a search query.
+ * This will direct the user to the appropriate page as long as an exact match is found.
+ * 
+ * A general query. This is a search query without a keyword. This will direct
+ * the user to the search page.
+ * 
+ * @type {import('@sveltejs/kit').RequestHandler}
+ */
+export async function GET({params, platform}) {
+    let query = params.query;
+    query = decodeURIComponent((query + '').replace(/\+/g, '%20'));
+
+    // This is the first word in query
+    let keyword = query.split(":")[0];
+    let queryWithoutKeyword = query.slice(keyword.length + 1).trim();
+
+    if (keyword === "std") {
+        const stdDescShards = await DescShardManager.create("std-stable");
+        let stdSearcher = new DocSearch(
+            "std",
+            await IndexManager.getStdStableIndex(),
+            "https://doc.rust-lang.org/",
+            stdDescShards,
+        );
+
+        let response = await stdSearcher.search(queryWithoutKeyword);
+        let firstEntry = response[0];
+        if (firstEntry) {
+            let valueToCheckFor = "std: " + firstEntry["path"] + "::" + firstEntry["name"];
+            if (valueToCheckFor == query) {
+                return Response.redirect(firstEntry["href"]);
+            }
+        }
+    } else if (keyword === "crate") {
+        const crateSearcher = new CrateSearch(await IndexManager.getCrateMapping(), await IndexManager.getCrateIndex());
+        let response = await crateSearcher.search(queryWithoutKeyword);
+        let firstEntry = response[0];
+        if (firstEntry) {
+            let valueToCheckFor = firstEntry["id"];
+            if (valueToCheckFor == queryWithoutKeyword) {
+                return Response.redirect("https://crates.io/crates/" + firstEntry["id"]);
+            }
+        }
+    }
+
+    return redirect(302, "/?q=" + query);
+}

--- a/src/routes/suggest/[query]/+server.js
+++ b/src/routes/suggest/[query]/+server.js
@@ -1,0 +1,103 @@
+import { IndexManager } from 'querylib';
+import { CrateSearch, DescShardManager, DocSearch } from 'querylib/search/index.js';
+
+/**
+ * This function behaves as a suggestion provider for the search queries.
+ * 
+ * This will return results in the format of a keyword followed by a colon and a completion.
+ * Format of the response is OpenSearch Suggestions 1.1.
+ * https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Suggestions/1.1/Draft%201.wiki
+ */
+export async function GET({params, platform}) {
+    let query = params.query;
+
+    let result = [];
+    result.push(query);
+
+    /**
+     * @type {string[]}
+     */
+    let completions = [];
+    /**
+     * @type {string[]}
+     * */
+    let desc = [];
+    /**
+     * @type {string[]}
+     * */
+    let urls = [];
+    
+    await stdSearch(query, completions, desc, urls, 4);
+    await crateSearch(query, completions, desc, urls, 3);
+
+    result.push(completions);
+    result.push(desc);
+    result.push(urls);
+
+    let res = Response.json(result);
+    res.headers.set("Content-Type", "application/x-suggestions+json")
+    return res;
+}
+
+/**
+ * Search for a standard library item.
+ * @param {string} query 
+ * @param {string[]} completions 
+ * @param {string[]} desc 
+ * @param {string[]} urls 
+ * @param {number} maxCount 
+ */
+async function stdSearch(query, completions, desc, urls, maxCount) {
+    const stdDescShards = await DescShardManager.create("std-stable");
+    let stdSearcher = new DocSearch(
+        "std",
+        await IndexManager.getStdStableIndex(),
+        "https://doc.rust-lang.org/",
+        stdDescShards,
+    );
+
+    let response = await stdSearcher.search(query);
+
+    let count = 0;
+    for (const entry of response) {
+        if (maxCount && count >= maxCount) {
+            break;
+        } else {
+            count += 1;
+        }
+
+        let entryDisplay = "std: " + entry["path"] + "::" + entry["name"];
+        entryDisplay = entryDisplay //+ " - " + entry["href"];
+        completions.push(entryDisplay);
+        desc.push(entry["desc"]);
+        urls.push(entry["href"]);
+    }
+}
+
+/**
+ * Search for a crate.
+ * @param {string} query 
+ * @param {string[]} completions 
+ * @param {string[]} desc 
+ * @param {string[]} urls 
+ * @param {number} maxCount 
+ */
+async function crateSearch(query, completions, desc, urls, maxCount) {
+    const crateSearcher = new CrateSearch(await IndexManager.getCrateMapping(), await IndexManager.getCrateIndex());
+    let response = crateSearcher.search(query);
+
+    let count = 0;
+    for (const entry of response) {
+        if (maxCount && count >= maxCount) {
+            break;
+        } else {
+            count += 1;
+        }
+
+        let entryDisplay = "crate: " + entry["id"];
+        entryDisplay = entryDisplay //+ " - " + "https://docs.rs/" + entry["id"];
+        completions.push(entryDisplay);
+        desc.push(entry["description"]);
+        urls.push("https://docs.rs/" + entry["id"]);
+    }
+}

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -2,5 +2,6 @@
   <ShortName>Query.rs</ShortName>
   <Description>A search engine for Rust.</Description>
   <Image width="16" height="16" type="image/x-icon">https://query.rs/favicon.ico</Image>
-  <Url type="text/html" method="get" template="https://query.rs?q={searchTerms}"/>
+  <Url type="text/html" method="get" template="https://query.rs/redirect/{searchTerms}"/>
+  <Url type="application/x-suggestions+json" template="https://query.rs/suggest/{searchTerms}"/>
 </OpenSearchDescription>


### PR DESCRIPTION
- Adds two server side pages
  - `suggest\[query]` provides suggestions. This includes only std and crates links currently
  - `redirect\[query]` allows direct redirects from suggestions without opening query.rs if the link is not found.
- Updated `opensearch.xml` file to support the above.

Fixes #15 

Tested on Firefox. Note that because this is SSR, we might want to enable caching so that Cloudflare's Caching can be effectively utilized and reduce overall costs. That is the reason i used full URLs instead of query parameters for both suggest and redirect. Cloudflare allows caching at URL level but might not do it when using a query parameter. Note that redirect may be further optimized by running it client-side rather than server side.