### PR TITLE
Disable crates, reduce overhead of std docs for SSR

### DIFF
--- a/src/routes/redirect/[query]/+server.js
+++ b/src/routes/redirect/[query]/+server.js
@@ -1,6 +1,7 @@
 import { redirect } from "@sveltejs/kit";
-import { DescShardManager, IndexManager } from "querylib";
-import { CrateSearch, DocSearch } from "querylib/search";
+import stdDescShards from "querylib/index/desc-shards/std";
+import searchIndex from "querylib/index/std-docs";
+import { DocSearch } from "querylib/search";
 
 /**
  * This function behaves as a redirector for the search queries.
@@ -18,17 +19,17 @@ export async function GET({params, platform}) {
     let query = params.query;
     query = decodeURIComponent((query + '').replace(/\+/g, '%20'));
 
-    // This is the first word in query
+    // // This is the first word in query
     let keyword = query.split(":")[0];
     let queryWithoutKeyword = query.slice(keyword.length + 1).trim();
 
     if (keyword === "std") {
-        const stdDescShards = await DescShardManager.create("std-stable");
+        const descShards = await StdShardManager.create();
         let stdSearcher = new DocSearch(
             "std",
-            await IndexManager.getStdStableIndex(),
+            structuredClone(searchIndex),
             "https://doc.rust-lang.org/",
-            stdDescShards,
+            descShards,
         );
 
         let response = await stdSearcher.search(queryWithoutKeyword);
@@ -40,16 +41,50 @@ export async function GET({params, platform}) {
             }
         }
     } else if (keyword === "crate") {
-        const crateSearcher = new CrateSearch(await IndexManager.getCrateMapping(), await IndexManager.getCrateIndex());
-        let response = await crateSearcher.search(queryWithoutKeyword);
-        let firstEntry = response[0];
-        if (firstEntry) {
-            let valueToCheckFor = firstEntry["id"];
-            if (valueToCheckFor == queryWithoutKeyword) {
-                return Response.redirect("https://crates.io/crates/" + firstEntry["id"]);
-            }
-        }
+        // const crateSearcher = new CrateSearch(mapping, crateIndex);
+        // let response = await crateSearcher.search(queryWithoutKeyword);
+        // let firstEntry = response[0];
+        // if (firstEntry) {
+        //     let valueToCheckFor = firstEntry["id"];
+        //     if (valueToCheckFor == queryWithoutKeyword) {
+        //         return Response.redirect("https://crates.io/crates/" + firstEntry["id"]);
+        //     }
+        // }
     }
 
     return redirect(302, "/?q=" + query);
+}
+
+class StdShardManager {
+    constructor() {
+        // A dummy descShards map to allow interact in librustdoc's DocSearch js
+        this.descShards = new DummyMap();
+        // The real crate -> desc shard map.
+        this._descShards = new Map();
+    }
+
+    static async create() {
+        const shardManager = new StdShardManager();
+        shardManager.addCrateDescShards();
+        return shardManager;
+    }
+
+    addCrateDescShards() {
+        const descShards = stdDescShards;
+        this._descShards = new Map([...this._descShards, ...descShards]);
+    }
+
+    // Load a single desc shard.
+    // Compatible with librustdoc main.js.
+    async loadDesc({ descShard, descIndex }) {
+        let crateDescShard = this._descShards.get(descShard.crate);
+        if (!crateDescShard || crateDescShard.length === 0) {
+            return null;
+        }
+        return crateDescShard[descShard.shard][descIndex];
+    }
+}
+
+class DummyMap {
+    set(_ke, _value) { }
 }


### PR DESCRIPTION
As requested by https://github.com/huhu/query.rs/pull/16#issuecomment-2310498635 

This PR removes crates search from suggestions and removes IndexManager which increases the overall file size. The final gzipped size is around 600KB with this change.