### PR TITLE
Enable cache-control header for suggestions

### DIFF
--- a/src/routes/suggest/[query]/+server.js
+++ b/src/routes/suggest/[query]/+server.js
@@ -36,7 +36,8 @@ export async function GET({ params }) {
     result.push(urls);
 
     let res = Response.json(result);
-    res.headers.set("Content-Type", "application/x-suggestions+json")
+    res.headers.set("Content-Type", "application/x-suggestions+json");
+    res.headers.set("Cache-Control", "public, max-age=3600");
     return res;
 }
 


### PR DESCRIPTION
See https://github.com/huhu/query.rs/issues/5#issuecomment-2310738654

Enables cache-control header so that response can be stored by both CloudFlare and the browser