### PR TITLE
Raycast extension continue with `suggest` api

### DIFF
--- a/raycast-extension/src/headless.js
+++ b/raycast-extension/src/headless.js
@@ -4,137 +4,127 @@ import DocSearch from "../../lib/search/docs/base.js";
 import searchIndex from "../../lib/index/std-docs.js";
 import stdDescShards from "../../lib/index/desc-shards/std.js";
 import { searchCrates } from "./crates.ts";
+import { suggest } from "./suggest.js";
 
 export async function initHeadlessOmnibox() {
-    let crateSearchCache = null;
-    let stdSearcher = new DocSearch(
-        "std",
-        searchIndex,
-        "https://doc.rust-lang.org/",
-        await DescShardManager.create(stdDescShards),
-    );
-    const headless = new HeadlessOmnibox({
-        onSearch: async (query) => {
-            return await stdSearcher.search(query);
+  let crateSearchCache = null;
+  const headless = new HeadlessOmnibox({
+    onSearch: async (query) => {
+      let suggestions = await suggest(query);
+      let results = suggestions.map((item) => {
+        return { content: item.url, description: item.name };
+      });
+      return results;
+    },
+    onAppend: async (query) => {
+      return [
+        {
+          content: `https://query.rs/?q=${query}`,
+          description: `Search keyword ${query} on https://query.rs`,
         },
-        onFormat: (index, doc) => {
-            let content = doc.href;
-            let description = doc.displayPath + `${doc.name}`;
-            if (doc.desc) {
-                description += ` - ${doc.desc}`;
-            }
+      ];
+    },
+  });
 
-            return { content, description };
-        },
-        onAppend: async (query) => {
-            return [
-                {
-                    content: `https://query.rs/?q=${query}`,
-                    description: `Search keyword ${query} on https://query.rs`,
-                },
-            ];
-        },
-    });
-
-    /**
-     * Search crates on crates.io directly
-     * @param {string} query
-     */
-    async function onSearchCrates(query) {
-        let results = [];
-        let keyword = query.replace(/[!\s]/g, "");
-        if (crateSearchCache && crateSearchCache.keyword === keyword) {
-            return crateSearchCache.results;
-        }
-        let crates = await searchCrates(keyword);
-        for (const crate of crates) {
-            results.push({
-                id: crate.id,
-                version: crate.max_stable_version,
-                description: crate.description,
-            });
-        }
-        crateSearchCache = { keyword, results };
-        return results;
+  /**
+   * Search crates on crates.io directly
+   * @param {string} query
+   */
+  async function onSearchCrates(query) {
+    let results = [];
+    let keyword = query.replace(/[!\s]/g, "");
+    if (crateSearchCache && crateSearchCache.keyword === keyword) {
+      return crateSearchCache.results;
     }
+    let crates = await searchCrates(keyword);
+    for (const crate of crates) {
+      results.push({
+        id: crate.id,
+        version: crate.max_stable_version,
+        description: crate.description,
+      });
+    }
+    crateSearchCache = { keyword, results };
+    return results;
+  }
 
-    headless.addPrefixQueryEvent("!", {
-        name: "docs.rs",
-        onSearch: onSearchCrates,
-        onFormat: (index, crate) => {
-            return {
-                content: `https://docs.rs/${crate.id}`,
-                description: `Docs.rs: <match>${crate.id}</match> v${crate.version} - <dim>${Compat.escape(Compat.eliminateTags(crate.description))}</dim>`,
-            };
+  headless.addPrefixQueryEvent("!", {
+    name: "docs.rs",
+    onSearch: onSearchCrates,
+    onFormat: (index, crate) => {
+      return {
+        content: `https://docs.rs/${crate.id}`,
+        description: `Docs.rs: <match>${crate.id}</match> v${crate.version} - <dim>${Compat.escape(Compat.eliminateTags(crate.description))}</dim>`,
+      };
+    },
+    onAppend: (query) => {
+      let keyword = query.replace(/[!\s]/g, "");
+      return [
+        {
+          content: "https://docs.rs/releases/search?query=" + encodeURIComponent(keyword),
+          description: "Search Rust crates for " + `<match>${keyword}</match>` + " on https://docs.rs",
         },
-        onAppend: (query) => {
-            let keyword = query.replace(/[!\s]/g, "");
-            return [
-                {
-                    content: "https://docs.rs/releases/search?query=" + encodeURIComponent(keyword),
-                    description: "Search Rust crates for " + `<match>${keyword}</match>` + " on https://docs.rs",
-                },
-            ];
-        },
-    });
+      ];
+    },
+  });
 
-    headless.addPrefixQueryEvent("!!", {
-        name: "crates.io",
-        onSearch: onSearchCrates,
-        onFormat: async (index, crate) => {
-            return {
-                content: `https://crates.io/crates/${crate.id}`,
-                description: `Crates.io: ${crate.id} v${crate.version} - <dim>${Compat.escape(Compat.eliminateTags(crate.description))}</dim>`,
-            };
+  headless.addPrefixQueryEvent("!!", {
+    name: "crates.io",
+    onSearch: onSearchCrates,
+    onFormat: async (index, crate) => {
+      return {
+        content: `https://crates.io/crates/${crate.id}`,
+        description: `Crates.io: ${crate.id} v${crate.version} - <dim>${Compat.escape(Compat.eliminateTags(crate.description))}</dim>`,
+      };
+    },
+    onAppend: async (query) => {
+      let keyword = query.replace(/[!\s]/g, "");
+      return [
+        {
+          content: `https://crates.io/search?q=` + encodeURIComponent(keyword),
+          description: "Search Rust crates for " + `<match>${keyword}</match>` + ` on https://crates.io`,
         },
-        onAppend: async (query) => {
-            let keyword = query.replace(/[!\s]/g, "");
-            return [
-                {
-                    content: `https://crates.io/search?q=` + encodeURIComponent(keyword),
-                    description: "Search Rust crates for " + `<match>${keyword}</match>` + ` on https://crates.io`,
-                },
-            ];
-        },
-    });
+      ];
+    },
+  });
 
-    headless.addPrefixQueryEvent("!!!", {
-        name: "Repository",
-        onSearch: onSearchCrates,
-        onFormat: (index, crate) => {
-            return {
-                content: `https://query.rs/repo/${crate.id}`,
-                description: `Repository: <match>${crate.id}</match> v${crate.version} - <dim>${Compat.escape(Compat.eliminateTags(crate.description))}</dim>`,
-            };
+  headless.addPrefixQueryEvent("!!!", {
+    name: "Repository",
+    onSearch: onSearchCrates,
+    onFormat: (index, crate) => {
+      return {
+        content: `https://query.rs/repo/${crate.id}`,
+        description: `Repository: <match>${crate.id}</match> v${crate.version} - <dim>${Compat.escape(Compat.eliminateTags(crate.description))}</dim>`,
+      };
+    },
+    onAppend: (query) => {
+      let keyword = query.replace(/[!\s]/g, "");
+      return [
+        {
+          content: "https://github.com/search?q=" + encodeURIComponent(keyword),
+          description: "Search Rust crates for " + `<match>${keyword}</match>` + " on https://github.com",
         },
-        onAppend: (query) => {
-            let keyword = query.replace(/[!\s]/g, "");
-            return [
-                {
-                    content: "https://github.com/search?q=" + encodeURIComponent(keyword),
-                    description: "Search Rust crates for " + `<match>${keyword}</match>` + " on https://github.com",
-                },
-            ];
-        },
-    });
-    headless.addRegexQueryEvent(/^`?e\d{2,4}`?$/i, {
-        name: "Error code",
-        onSearch: async (query) => {
-            query = query.replace("`", "");
-            let baseIndex = parseInt(query.slice(1).padEnd(4, "0"));
-            let result = [];
-            for (let i = 0; i < 10; i++) {
-                let errorIndex = "E" + String(baseIndex++).padStart(4, "0").toUpperCase();
-                result.push(errorIndex);
-            }
+      ];
+    },
+  });
+  headless.addRegexQueryEvent(/^`?e\d{2,4}`?$/i, {
+    name: "Error code",
+    onSearch: async (query) => {
+      query = query.replace("`", "");
+      let baseIndex = parseInt(query.slice(1).padEnd(4, "0"));
+      let result = [];
+      for (let i = 0; i < 10; i++) {
+        let errorIndex = "E" + String(baseIndex++).padStart(4, "0").toUpperCase();
+        result.push(errorIndex);
+      }
 
-            return result.map((errorCode) => {
-                return {
-                    content: `https://doc.rust-lang.org/error_codes/${errorCode}.html`,
-                    description: `Open error code <match>${errorCode}</match> on error codes index`,
-                };
-            });
-        },
-    });
-    return headless;
+      return result.map((errorCode) => {
+        return {
+          content: `https://doc.rust-lang.org/error_codes/${errorCode}.html`,
+          description: `Open error code <match>${errorCode}</match> on error codes index`,
+        };
+      });
+    },
+  });
+  return headless;
 }

--- a/raycast-extension/src/index.tsx
+++ b/raycast-extension/src/index.tsx
@@ -4,84 +4,89 @@ import { initHeadlessOmnibox } from "./headless.js";
 import { HeadlessOmnibox } from "omnibox-js";
 
 export default function Command() {
-    const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [headless, setHeadless] = useState<HeadlessOmnibox | null>(null);
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [headless, setHeadless] = useState<HeadlessOmnibox | null>(null);
 
-    useEffect(() => {
-        async function initialize() {
-            const headlessOmnibox = await initHeadlessOmnibox();
-            setHeadless(headlessOmnibox);
-            setIsLoading(false);
-        }
-        initialize();
-    }, []);
+  useEffect(() => {
+    async function initialize() {
+      const headlessOmnibox = await initHeadlessOmnibox();
+      setHeadless(headlessOmnibox);
+      setIsLoading(false);
+    }
+    initialize();
+  }, []);
 
-    const handleSearch = async (text: string) => {
-        if (!headless) return;
+  const handleSearch = async (text: string) => {
+    if (!headless) return;
 
-        setIsLoading(true);
-        const { results } = await headless.search(text);
-        setSearchResults(
-            results.map((result) => ({
-                name: result.content,
-                description: result.description,
-                url: result.content,
-            })),
-        );
-        setIsLoading(false);
-    };
+    if (text.length === 0) {
+      setSearchResults([]);
+      return;
+    }
 
-    return (
-        <List isLoading={isLoading} onSearchTextChange={handleSearch} searchBarPlaceholder="Search..." throttle>
-            {searchResults.map((searchResult) => (
-                <SearchListItem key={searchResult.url} searchResult={searchResult} />
-            ))}
-            <List.EmptyView
-                icon={{ source: "icon.png" }}
-                title="Query.rs"
-                description="A search engine for Rust"
-                actions={
-                    <ActionPanel>
-                        <ActionPanel.Section>
-                            <Action.OpenInBrowser title="Open in Browser" url={"https://query.rs"} />
-                        </ActionPanel.Section>
-                    </ActionPanel>
-                }
-            />
-        </List>
+    setIsLoading(true);
+    const { results } = await headless.search(text);
+    setSearchResults(
+      results.map((result) => ({
+        name: result.content,
+        description: result.description,
+        url: result.content,
+      })),
     );
+    setIsLoading(false);
+  };
+
+  return (
+    <List isLoading={isLoading} onSearchTextChange={handleSearch} searchBarPlaceholder="Search..." throttle>
+      {searchResults.map((searchResult) => (
+        <SearchListItem key={searchResult.url} searchResult={searchResult} />
+      ))}
+      <List.EmptyView
+        icon={{ source: "icon.png" }}
+        title="Query.rs"
+        description="A search engine for Rust"
+        actions={
+          <ActionPanel>
+            <ActionPanel.Section>
+              <Action.OpenInBrowser title="Open in Browser" url={"https://query.rs"} />
+            </ActionPanel.Section>
+          </ActionPanel>
+        }
+      />
+    </List>
+  );
 }
 
 function SearchListItem({ searchResult }: { searchResult: SearchResult }) {
-    return (
-        <List.Item
-            title={searchResult.description}
-            icon={getIcon(searchResult.url)}
-            actions={
-                <ActionPanel>
-                    <ActionPanel.Section>
-                        <Action.OpenInBrowser title="Open in Browser" url={searchResult.url} />
-                    </ActionPanel.Section>
-                </ActionPanel>
-            }
-        />
-    );
+  return (
+    <List.Item
+      title={searchResult.description}
+      icon={getIcon(searchResult.url)}
+      actions={
+        <ActionPanel>
+          <ActionPanel.Section>
+            <Action.OpenInBrowser title="Open in Browser" url={searchResult.url} />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+    />
+  );
 }
 
 function getIcon(url: string): Image.ImageLike {
-    if (url.startsWith("https://crates.io")) {
-        return { source: "crate.png" };
-    } else if (url.startsWith("https://doc.rust-lang.org")) {
-        return { source: "rust.png" };
-    } else if (url.startsWith("https://docs.rs")) {
-        return { source: "docs.png" };
-    } else {
-        return { source: "icon.png" };
-    }
+  if (url.startsWith("https://crates.io")) {
+    return { source: "crate.png" };
+  } else if (url.startsWith("https://doc.rust-lang.org")) {
+    return { source: "rust.png" };
+  } else if (url.startsWith("https://docs.rs")) {
+    return { source: "docs.png" };
+  } else {
+    return { source: "icon.png" };
+  }
 }
 
 interface SearchResult {
-    description: string;
-    url: string;
+  description: string;
+  url: string;
 }

--- a/raycast-extension/src/index.tsx
+++ b/raycast-extension/src/index.tsx
@@ -3,9 +3,33 @@ import { useState, useEffect } from "react";
 import { initHeadlessOmnibox } from "./headless.js";
 import { HeadlessOmnibox } from "omnibox-js";
 
+type SearchType = { id: string; name: string, prefixQueryEvent: string };
+
+function SearchTypeDropdown(props: { searchTypes: SearchType[]; onSearchTypeChange: (newValue: string) => void }) {
+  const { searchTypes, onSearchTypeChange } = props;
+  return (
+    <List.Dropdown
+      tooltip="Select Search Type"
+      storeValue={true}
+      onChange={(newValue) => {
+        onSearchTypeChange(newValue);
+      }}
+    >
+      <List.Dropdown.Section>
+        {searchTypes.map((searchType) => (
+          <List.Dropdown.Item key={searchType.id} title={searchType.name} value={searchType.prefixQueryEvent} />
+        ))}
+      </List.Dropdown.Section>
+    </List.Dropdown>
+  );
+}
+
 export default function Command() {
+  const [searchText, setSearchText] = useState("");
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  const [prefixQueryEvent, setPrefixQueryEvent] = useState("");
   const [headless, setHeadless] = useState<HeadlessOmnibox | null>(null);
 
   useEffect(() => {
@@ -18,6 +42,8 @@ export default function Command() {
   }, []);
 
   const handleSearch = async (text: string) => {
+    setSearchText(text);
+
     if (!headless) return;
 
     if (text.length === 0) {
@@ -26,7 +52,12 @@ export default function Command() {
     }
 
     setIsLoading(true);
-    const { results } = await headless.search(text);
+    const { results } = await headless.search(prefixQueryEvent + text);
+    // Remove pagination tip from the first result
+    const paginationTipRegex = /\s\|\sPage\s\[\d+\/\d+\],\sappend\s'.+?'\sto\s?page\sdown/;
+    if (results.length > 0) {
+      results[0].description = results[0].description.replace(paginationTipRegex, "");
+    }
     setSearchResults(
       results.map((result) => ({
         name: result.content,
@@ -37,8 +68,26 @@ export default function Command() {
     setIsLoading(false);
   };
 
+  const searchTypes: SearchType[] = [
+    { id: "1", name: "Std", prefixQueryEvent: "" },
+    { id: "2", name: "Docs", prefixQueryEvent: "!" },
+    { id: "3", name: "Crates", prefixQueryEvent: "!!" },
+    { id: "4", name: "Repository", prefixQueryEvent: "!!!" },
+  ];
+  const onSearchTypeChange = (newValue: string) => {
+    setPrefixQueryEvent(newValue);
+    handleSearch(searchText);
+  };
+
   return (
-    <List isLoading={isLoading} onSearchTextChange={handleSearch} searchBarPlaceholder="Search..." throttle>
+    <List
+      isLoading={isLoading}
+      searchText={searchText}
+      onSearchTextChange={handleSearch}
+      searchBarPlaceholder="Search..."
+      searchBarAccessory={<SearchTypeDropdown searchTypes={searchTypes} onSearchTypeChange={onSearchTypeChange} />}
+      throttle
+    >
       {searchResults.map((searchResult) => (
         <SearchListItem key={searchResult.url} searchResult={searchResult} />
       ))}

--- a/raycast-extension/src/suggest.ts
+++ b/raycast-extension/src/suggest.ts
@@ -1,0 +1,29 @@
+
+import fetch from "node-fetch";
+
+export async function suggest(query: string): Promise<any[]> {
+  try {
+    const response = await fetch(`https://query.rs/suggest/${encodeURIComponent(query)}`, {
+      headers: {
+        "User-Agent": "Query.rs Raycast Extension",
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    const suggestions = data[1] || [];
+
+    const formattedSuggestions = suggestions.map(item => {
+      const [name, url] = item.split(' - ');
+      return { name, url };
+    }).filter(suggestion => suggestion.url);
+
+    return formattedSuggestions;
+  } catch (error) {
+    console.error("Error query suggestions:", error);
+    return [];
+  }
+}


### PR DESCRIPTION
In discussion #24 , we addressed the memory limitation in the Raycast extension worker. I experimented with various methods and explored [usestreamjson](https://developers.raycast.com/utilities/react-hooks/usestreamjson) until I discovered the `https://query.rs/suggest/query` API endpoint. This resolved the memory issue.

Though, as mentioned in #26, the `suggest` API endpoint only utilizes the [std-docs](https://github.com/huhu/query.rs/blob/03b1859e03ff6a369b8ec3c1709508f17765edf8/src/routes/suggest/%5Bquery%5D/%2Bserver.js#L4) currently. Nevertheless, using the open search API allows us to enhance the Raycast extension with `suggest` open search support, simultaneously improving the search experience. 

### Showcases

- search std doc by default, support raycast extension dropdown [`⌘+P`] to quick switch search type.

![image](https://github.com/user-attachments/assets/c803673a-82d1-4356-a32c-ae812f604abf)

![image](https://github.com/user-attachments/assets/671b588d-68ef-417f-b8a2-cd58c1414e51)

![image](https://github.com/user-attachments/assets/963fcf82-2688-439d-9db7-31a6caeec1f0)

![image](https://github.com/user-attachments/assets/c0ec1864-5786-46e2-96fd-f3b0676fa7fc)


